### PR TITLE
Updated: stop_simulation() and warning() implementations

### DIFF
--- a/StandaloneFMU/src/%FMI_PREFIX%Functions.c
+++ b/StandaloneFMU/src/%FMI_PREFIX%Functions.c
@@ -726,6 +726,11 @@ fmi2Status fmi2DoStep(fmi2Component c,
 			/* we're done */
 			return %FMI_PREFIX%Error;
 		}
+		/* Check for stop simulation */
+		if (%VARPREFIX%model_instance->stop_simulation == XXTRUE)
+		{
+			return %FMI_PREFIX%Error;
+		}
 
 		/* Call the submodel to calculate the output, and increase the time as well */
 		%FUNCTIONPREFIX%CalculateSubmodel (%VARPREFIX%model_instance, %VARPREFIX%model_instance->time);

--- a/StandaloneFMU/src/xxfuncs.c
+++ b/StandaloneFMU/src/xxfuncs.c
@@ -453,26 +453,6 @@ XXDouble XXTimeDelay (XXDouble argument, XXDouble time, XXInteger id)
 }
 
 %ENDIF%
-%IF%%NUMBEROF_WARNSTATEMENT%
-XXBoolean XXWarning (XXString message, XXInteger id)
-{
-#if defined _MSC_VER
-#pragma message("warning: The 20-sim 'warning' function is not yet implemented in this code generation template")
-#elif defined __GNUC__
-#warning The 20-sim 'warning' function is not yet implemented in this code generation template
-#endif
-	return 0;
-}
-
-%ENDIF%
-%IF%%NUMBEROF_STOPSTATEMENT%
-XXBoolean XXStopSimulation (XXString message, XXInteger id)
-{
-	%VARPREFIX%stop_simulation = XXTRUE;
-	return 0;
-}
-
-%ENDIF%
 %IF%%NUMBEROF_REALTIME%
 static time_t xx_start_run_time = 0;
 

--- a/StandaloneFMU/src/xxfuncs.h
+++ b/StandaloneFMU/src/xxfuncs.h
@@ -142,12 +142,6 @@ XXBoolean XXTimeEvent (XXDouble argument, XXInteger id);
 %IF%%NUMBEROF_TDELAYFUNCTION%
 XXDouble XXTimeDelay (XXDouble argument, XXDouble time, XXInteger id);
 %ENDIF%
-%IF%%NUMBEROF_WARNSTATEMENT%
-XXBoolean XXWarning (XXString message, XXInteger id);
-%ENDIF%
-%IF%%NUMBEROF_STOPSTATEMENT%
-XXBoolean XXStopSimulation (XXString message, XXInteger id);
-%ENDIF%
 %IF%%NUMBEROF_REALTIME%
 XXDouble XXRealTime(void);
 %ENDIF%

--- a/StandaloneFMU/src/xxmodel.c
+++ b/StandaloneFMU/src/xxmodel.c
@@ -255,7 +255,7 @@ XXDouble %FUNCTIONPREFIX%ModelDelay (XXModelInstance* %VARPREFIX%model_instance,
 
 %ENDIF%
 %IF%%NUMBEROF_INITIALFUNCTION%
-XXDouble XXModelInitialValue (XXModelInstance* %VARPREFIX%model_instance, XXDouble argument, XXInteger identifier)
+XXDouble %FUNCTIONPREFIX%ModelInitialValue (XXModelInstance* %VARPREFIX%model_instance, XXDouble argument, XXInteger identifier)
 {
 	/* The storage array '%VARPREFIX%initial_value_array' is declared in xxmodel.c because its size is model dependent */
 	XXDouble value;
@@ -270,6 +270,30 @@ XXDouble XXModelInitialValue (XXModelInstance* %VARPREFIX%model_instance, XXDoub
 		value = %VARPREFIX%model_instance->initial_value_array[identifier];
 	}
 	return value;
+}
+
+%ENDIF%
+%IF%%NUMBEROF_WARNSTATEMENT%
+XXBoolean %FUNCTIONPREFIX%ModelWarning (XXModelInstance* %VARPREFIX%model_instance, XXString message, XXInteger id)
+{
+	if(%VARPREFIX%model_instance->fmiCallbackFunctions != NULL && %VARPREFIX%model_instance->fmiCallbackFunctions->logger != NULL)
+	{
+		%VARPREFIX%model_instance->fmiCallbackFunctions->logger(NULL, "%SUBMODEL_NAME%", fmi2Warning, "warning", message);
+	}
+	return 0;
+}
+
+%ENDIF%
+%IF%%NUMBEROF_STOPSTATEMENT%
+XXBoolean %FUNCTIONPREFIX%ModelStopSimulation (XXModelInstance* %VARPREFIX%model_instance, XXString message, XXInteger id)
+{
+	%VARPREFIX%model_instance->stop_simulation = XXTRUE;
+
+	if(%VARPREFIX%model_instance->fmiCallbackFunctions != NULL && %VARPREFIX%model_instance->fmiCallbackFunctions->logger != NULL)
+	{
+		%VARPREFIX%model_instance->fmiCallbackFunctions->logger(NULL, "%SUBMODEL_NAME%", fmi2Error, "error", message);
+	}
+	return 0;
 }
 
 %ENDIF%

--- a/StandaloneFMU/src/xxmodel.h
+++ b/StandaloneFMU/src/xxmodel.h
@@ -215,5 +215,13 @@ XXDouble %FUNCTIONPREFIX%ModelDelay (XXModelInstance* %VARPREFIX%model_instance,
 XXDouble %FUNCTIONPREFIX%ModelInitialValue (XXModelInstance* %VARPREFIX%model_instance, XXDouble argument, XXInteger identifier);
 #define XXInitialValue(arg, id) %FUNCTIONPREFIX%ModelInitialValue(%VARPREFIX%model_instance, arg, id)
 %ENDIF%
+%IF%%NUMBEROF_WARNSTATEMENT%
+XXBoolean %FUNCTIONPREFIX%ModelWarning (XXModelInstance* %VARPREFIX%model_instance, XXString message, XXInteger id);
+#define XXWarning(message, id) %FUNCTIONPREFIX%ModelWarning(%VARPREFIX%model_instance, message, id)
+%ENDIF%
+%IF%%NUMBEROF_STOPSTATEMENT%
+XXBoolean %FUNCTIONPREFIX%ModelStopSimulation (XXModelInstance* %VARPREFIX%model_instance, XXString message, XXInteger id);
+#define XXStopSimulation(message, id) %FUNCTIONPREFIX%ModelStopSimulation(%VARPREFIX%model_instance, message, id)
+%ENDIF%
 
 #endif


### PR DESCRIPTION
Fixed: stop_simulation() and warning() are now implemented and multi-instance compatible

Fixes #23
