### PR TITLE
Add <SourceFiles> section to the modelDescription.xml

### DIFF
--- a/StandaloneFMU/Makefile
+++ b/StandaloneFMU/Makefile
@@ -11,7 +11,7 @@ BUILD = project/gcc
 SRC   = src
 
 XXSIM_SOURCES = EulerAngles.c \
-	motionprofiles.c \
+	MotionProfiles.c \
 	xxfuncs.c \
 	xxinteg.c \
 	xxinverse.c \

--- a/StandaloneFMU/template/mcf2modelDescription.xsl
+++ b/StandaloneFMU/template/mcf2modelDescription.xsl
@@ -106,6 +106,17 @@
 			<xsl:attribute name="canGetAndSetFMUstate">false</xsl:attribute>
 			<xsl:attribute name="canSerializeFMUstate">false</xsl:attribute>
 			<xsl:attribute name="providesDirectionalDerivative">false</xsl:attribute>
+			<xsl:element name="SourceFiles">
+				<xsl:element name="File"><xsl:attribute name="name">EulerAngles.c</xsl:attribute></xsl:element>
+				<xsl:element name="File"><xsl:attribute name="name">MotionProfiles.c</xsl:attribute></xsl:element>
+				<xsl:element name="File"><xsl:attribute name="name">xxfuncs.c</xsl:attribute></xsl:element>
+				<xsl:element name="File"><xsl:attribute name="name">xxinteg.c</xsl:attribute></xsl:element>
+				<xsl:element name="File"><xsl:attribute name="name">xxinverse.c</xsl:attribute></xsl:element>
+				<xsl:element name="File"><xsl:attribute name="name">xxmatrix.c</xsl:attribute></xsl:element>
+				<xsl:element name="File"><xsl:attribute name="name">xxmodel.c</xsl:attribute></xsl:element>
+				<xsl:element name="File"><xsl:attribute name="name">xxsubmod.c</xsl:attribute></xsl:element>
+				<xsl:element name="File"><xsl:attribute name="name">xxTable2D.c</xsl:attribute></xsl:element>
+			</xsl:element>
 		</xsl:element>
 %ENDIF%
 


### PR DESCRIPTION
According to page 66 FMI 2.0 standard:

```
sources // Optional directory containing all C sources
// all needed C sources and C header files to compile and link the FMU
// with exception of: fmi2TypesPlatform.h , fmi2FunctionTypes.h and fmi2Functions.h
// The files to be compiled (but not the files included from these files)
// have to be reported in the xml-file under the structure
// <ModelExchange><SourceFiles> … and <CoSimulation><SourceFiles>
```
