### PR TITLE
fixes #29 it ignores \r, it have been tested on window64, gentoo and mac sierra

### DIFF
--- a/StandaloneFMU/src/xxTable2D.c
+++ b/StandaloneFMU/src/xxTable2D.c
@@ -422,6 +422,8 @@ XXBoolean count_data_dimensions(FILE* fp, XXInteger* rows, XXInteger* columns)
 
         switch (c)
         {
+						case '\r':
+							continue;
             case ' ':
             case '\t':
                 if (readingVal){


### PR DESCRIPTION
This makes the FMU exporter run on all platforms when using external files.

Tested with:

* Mac Sierra
* gentoo
* windows 10 x64